### PR TITLE
FOGL-2435 requirements.sh file usage for make_deb and postinst scripts and other minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build
 
 # packaging
 packages/build
+
+# Editor
+.idea/
+

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ project in your home directory.
 
   requirements.sh
 
-If you require to place the freeopcua code elsewhere you may pass the requirements.sh script anrargument
+If you require to place the freeopcua code elsewhere you may pass the requirements.sh script an argument
 of a directory name to use.
 
 .. code-block:: console

--- a/make_deb
+++ b/make_deb
@@ -116,8 +116,11 @@ libdir=${FOGLAMP_ROOT}/cmake_build/C/lib; [ -d ${libdir} ] && LD_LIBRARY_PATH=$(
 [ "$libPathSet" -eq "0" ] && echo "Unable to set/update LD_LIBRARY_PATH to include path of Foglamp shared libraries: check whether ${FOGLAMP_ROOT}/lib or ${FOGLAMP_ROOT}/cmake_build/C/lib exists" && exit 1
 
 # Build freeopcua first
-cd /tmp; rm -rf freeopcua; git clone https://github.com/FreeOpcUa/freeopcua.git; cd freeopcua; export FREEOPCUA=`pwd`;
-sed -i '/option(SSL_SUPPORT_MBEDTLS/s/ON/OFF/' CMakeLists.txt; mkdir build; cd build; cmake ..; make; cd ${GIT_ROOT}
+DIR=/tmp
+FREEOPCUA=freeopcua
+rm -rf ${DIR}/${FREEOPCUA}
+./requirements.sh ${DIR}
+export FREEOPCUA=${DIR}/${FREEOPCUA}
 
 # Build plugin
 rm -rf build; mkdir ./build; cd ./build; cmake ..; make; cd ..
@@ -145,6 +148,7 @@ mkdir -p usr/local/foglamp
 cd usr/local/foglamp
 mkdir -p "plugins/${plugin_type}/${plugin_install_dirname}"
 cp -R --preserve=links ${GIT_ROOT}/build/lib*.so* "plugins/${plugin_type}/${plugin_install_dirname}"
+cp ${GIT_ROOT}/requirements.sh ./plugins/${plugin_type}/${plugin_install_dirname}
 echo "Done."
 
 # Build the package

--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: armhf
-Depends: foglamp
+Depends: foglamp,git,libboost-filesystem-dev,libboost-program-options-dev
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/packages/Debian/common/DEBIAN/postint
+++ b/packages/Debian/common/DEBIAN/postint
@@ -21,14 +21,28 @@
 ## @postinst DEBIAN/postinst
 ## This script is used to execute post installation tasks.
 ##
-## Author: Massimiliano Pinto
+## Author: Massimiliano Pinto, Ashish Jabble
 ##
 ##--------------------------------------------------------------------
 
 set -e
 
+DIR=/tmp
+FREEOPCUA=freeopcua
+
+
 set_files_ownership () {
     chown -R root:root /usr/local/foglamp/plugins/south/opcua
 }
 
+install_requirements () {
+    rm -rf ${DIR}/${FREEOPCUA}
+    sh /usr/local/foglamp/plugins/south/opcua/requirements.sh ${DIR}
+    export FREEOPCUA=${DIR}/${FREEOPCUA}
+}
+
 set_files_ownership
+install_requirements
+
+echo "opcua plugin is installed"
+

--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: amd64
-Depends: foglamp
+Depends: foglamp,git,libboost-filesystem-dev,libboost-program-options-dev
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,4 +1,4 @@
-#!//usr/bin/env bash
+#!/usr/bin/env bash
 
 ##--------------------------------------------------------------------
 ## Copyright (c) 2019 Dianomic Systems
@@ -48,6 +48,6 @@ if [ ! -d $directory/freeopcua ]; then
 	cmake ..
 	make
 	cd ..
-	echo Set the environemnt variable FREEOPCUA to `pwd`
+	echo Set the environment variable FREEOPCUA to `pwd`
 	echo export FREEOPCUA=`pwd`
 fi


### PR DESCRIPTION
- [x] make_deb now uses requirements.sh
- [x] control file updated
- [x] Debian working fine and now discovery of plugin is okay

```
pi@raspberrypi:~/foglamp-south-opcua $ sudo dpkg -c /home/pi/foglamp-south-opcua/packages/build/foglamp-south-opcua-1.0.0-armhf.deb 
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/local/
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/local/foglamp/
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/local/foglamp/plugins/
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/local/foglamp/plugins/south/
drwxr-xr-x pi/pi             0 2019-02-26 08:06 ./usr/local/foglamp/plugins/south/opcua/
-rwxr-xr-x pi/pi      18801008 2019-02-26 08:06 ./usr/local/foglamp/plugins/south/opcua/libopcua.so.1
-rwxr-xr-x pi/pi          1859 2019-02-26 08:06 ./usr/local/foglamp/plugins/south/opcua/requirements.sh
lrwxrwxrwx pi/pi             0 2019-02-26 08:06 ./usr/local/foglamp/plugins/south/opcua/libopcua.so -> libopcua.so.1
```

```
pi@raspberrypi:~ $ sudo apt install /var/cache/apt/archives/foglamp-south-opcua-1.0.0-armhf.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'foglamp-south-opcua' instead of '/var/cache/apt/archives/foglamp-south-opcua-1.0.0-armhf.deb'
The following packages were automatically installed and are no longer required:
  cmake cmake-data libarchive13 libjsoncpp1 liblzo2-2 libnginx-mod-http-echo libsqlite3-dev libssl-dev libssl-doc libuv1 nginx-common
  nginx-light uuid-dev
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  git git-man libboost-filesystem-dev libboost-filesystem1.62-dev libboost-program-options-dev libboost-program-options1.62-dev
  libboost-program-options1.62.0 liberror-perl
Suggested packages:
  git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-arch git-cvs git-mediawiki git-svn
The following NEW packages will be installed:
  foglamp-south-opcua git git-man libboost-filesystem-dev libboost-filesystem1.62-dev libboost-program-options-dev
  libboost-program-options1.62-dev libboost-program-options1.62.0 liberror-perl
0 upgraded, 9 newly installed, 0 to remove and 0 not upgraded.
Need to get 5,238 kB/8,587 kB of archives.
After this operation, 28.4 MB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf liberror-perl all 0.17024-1 [26.9 kB]
Get:2 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf git-man all 1:2.11.0-3+deb9u4 [1,433 kB]
Get:3 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf git armhf 1:2.11.0-3+deb9u4 [3,390 kB]
Get:4 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf libboost-filesystem1.62-dev armhf 1.62.0+dfsg-4 [66.1 kB]            
Get:5 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf libboost-filesystem-dev armhf 1.62.0.1+b4 [3,732 B]                  
Get:6 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf libboost-program-options1.62.0 armhf 1.62.0+dfsg-4 [136 kB]          
Get:7 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf libboost-program-options1.62-dev armhf 1.62.0+dfsg-4 [178 kB]        
Get:8 http://raspbian.mirror.net.in/raspbian/raspbian stretch/main armhf libboost-program-options-dev armhf 1.62.0.1+b4 [3,716 B]             
Fetched 5,238 kB in 11s (448 kB/s)                                                                                                            
Selecting previously unselected package liberror-perl.
(Reading database ... 55488 files and directories currently installed.)
Preparing to unpack .../0-liberror-perl_0.17024-1_all.deb ...
Unpacking liberror-perl (0.17024-1) ...
Selecting previously unselected package git-man.
Preparing to unpack .../1-git-man_1%3a2.11.0-3+deb9u4_all.deb ...
Unpacking git-man (1:2.11.0-3+deb9u4) ...
Selecting previously unselected package git.
Preparing to unpack .../2-git_1%3a2.11.0-3+deb9u4_armhf.deb ...
Unpacking git (1:2.11.0-3+deb9u4) ...
Selecting previously unselected package libboost-filesystem1.62-dev:armhf.
Preparing to unpack .../3-libboost-filesystem1.62-dev_1.62.0+dfsg-4_armhf.deb ...
Unpacking libboost-filesystem1.62-dev:armhf (1.62.0+dfsg-4) ...
Selecting previously unselected package libboost-filesystem-dev:armhf.
Preparing to unpack .../4-libboost-filesystem-dev_1.62.0.1+b4_armhf.deb ...
Unpacking libboost-filesystem-dev:armhf (1.62.0.1+b4) ...
Selecting previously unselected package libboost-program-options1.62.0:armhf.
Preparing to unpack .../5-libboost-program-options1.62.0_1.62.0+dfsg-4_armhf.deb ...
Unpacking libboost-program-options1.62.0:armhf (1.62.0+dfsg-4) ...
Selecting previously unselected package libboost-program-options1.62-dev:armhf.
Preparing to unpack .../6-libboost-program-options1.62-dev_1.62.0+dfsg-4_armhf.deb ...
Unpacking libboost-program-options1.62-dev:armhf (1.62.0+dfsg-4) ...
Selecting previously unselected package libboost-program-options-dev:armhf.
Preparing to unpack .../7-libboost-program-options-dev_1.62.0.1+b4_armhf.deb ...
Unpacking libboost-program-options-dev:armhf (1.62.0.1+b4) ...
Selecting previously unselected package foglamp-south-opcua.
Preparing to unpack .../8-foglamp-south-opcua-1.0.0-armhf.deb ...

DIR=/tmp
+ DIR=/tmp
FREEOPCUA=freeopcua
+ FREEOPCUA=freeopcua

install_requirements () {
    rm -rf ${DIR}/${FREEOPCUA}
    ls -la /usr/local/foglamp/plugins/south/opcua/requirements.sh
    strace /bin/sh /usr/local/foglamp/plugins/south/opcua/requirements.sh ${DIR}
    export FREEOPCUA=${DIR}/${FREEOPCUA}
}

#install_requirements
Unpacking foglamp-south-opcua (1.0.0) ...
Setting up git-man (1:2.11.0-3+deb9u4) ...
Setting up libboost-filesystem1.62-dev:armhf (1.62.0+dfsg-4) ...
Setting up liberror-perl (0.17024-1) ...
Setting up libboost-program-options1.62.0:armhf (1.62.0+dfsg-4) ...
Setting up libboost-program-options1.62-dev:armhf (1.62.0+dfsg-4) ...
Setting up libboost-filesystem-dev:armhf (1.62.0.1+b4) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Processing triggers for man-db (2.7.6.1-2) ...
Setting up git (1:2.11.0-3+deb9u4) ...
Setting up libboost-program-options-dev:armhf (1.62.0.1+b4) ...
Setting up foglamp-south-opcua (1.0.0) ...
```