### PR TITLE
FOGL-3186 add opcuaserver to the list of static libraries (requirements.sh) [1.7.0 RC]

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -63,6 +63,7 @@ if [ ! -d $directory/freeopcua ]; then
 		-e 's/add_library(opcuaclient/add_library(opcuaclient STATIC/' \
 		-e 's/add_library(opcuacore/add_library(opcuacore STATIC/' \
 		-e 's/add_library(opcuaprotocol/add_library(opcuaprotocol STATIC/' \
+		-e 's/add_library(opcuaserver/add_library(opcuaserver STATIC/' \
 		< CMakeLists.txt > CMakeLists.txt.$$ && mv CMakeLists.txt CMakeLists.txt.orig && \
 		mv CMakeLists.txt.$$ CMakeLists.txt
 	cd build


### PR DESCRIPTION
It made me confused why it is generating new hash for this. It is expecting `5e22ee` same commit #40 

_But anyway file changes are correct_